### PR TITLE
Add 'olympic' links to sitemaps and site lists

### DIFF
--- a/public/hamusata.f5.si-sitemap.xml
+++ b/public/hamusata.f5.si-sitemap.xml
@@ -29,6 +29,7 @@
   <url><loc>https://lite.hamusata.f5.si</loc></url>
   <url><loc>https://moji.hamusata.f5.si</loc></url>
   <url><loc>https://mono.hamusata.f5.si</loc></url>
+  <url><loc>https://olympic.hamusata.f5.si</loc></url>
   <url><loc>https://omikuji.hamusata.f5.si</loc></url>
   <url><loc>https://password.hamusata.f5.si</loc></url>
   <url><loc>https://password-create.hamusata.f5.si</loc></url>

--- a/public/hamuzon.github.io-sitemap.xml
+++ b/public/hamuzon.github.io-sitemap.xml
@@ -110,6 +110,10 @@
   </url>
 
   <url>
+    <loc>https://hamuzon.github.io/olympic/</loc>
+  </url>
+
+  <url>
     <loc>https://hamuzon.github.io/omikuji/</loc>
   </url>
 

--- a/sites.js
+++ b/sites.js
@@ -23,6 +23,7 @@ const sitesData = {
     { href: "http://discord-tools.hamusata.f5.si/", text: "📱 Discord Tools 🖥️ / Hamusata ", openInSameTab: true },
     { href: "https://globe.world.hamusata.f5.si/", text: "🌍️ アクセス位置共有 🌐 / (世界のどこからをリアルタイムで表示)", openInSameTab: true },
     { href: "https://video-hub.hamusata.f5.si/", text: "📹️Video　Player Tool HUB　⏯️", openInSameTab: true },
+    { href: "http://olympic.hamusata.f5.si/", text: "🏟️ Olympic Countdown / オリンピック関連カウントダウン 🎖️", openInSameTab: true },
 ],
 
   hamuzonGitHubIO: [
@@ -45,6 +46,7 @@ const sitesData = {
     { href: "https://hamuzon.github.io/editor/", text: "📝 ファイルエディター / File Editor　-Hamuzon", openInSameTab: true },
     { href: "https://hamuzon.github.io/discord-tools/", text: "📱 Discord Tools 🖥️ /　-Hamuzon", openInSameTab: true },
     { href: "https://hamuzon.github.io/Video-hub/", text: "📹️Video　Player Tool HUB　⏯️ /　-Hamuzon", openInSameTab: true },
+    { href: "https://hamuzon.github.io/olympic/", text: "🏟️ Olympic Countdown / オリンピック関連カウントダウン 🎖️ - Hamuzon", openInSameTab: true },
   ],
 
   wwwLinkSF5Si: [


### PR DESCRIPTION
### Motivation
- Add the Olympic/countdown site to the public site indexes and navigation so the new page is discoverable in sitemaps and the site lists.

### Description
- Inserted `olympic` entries into `public/hamusata.f5.si-sitemap.xml` and `public/hamuzon.github.io-sitemap.xml` and added corresponding link objects to the `homeHamusata` and `hamuzonGitHubIO` arrays in `sites.js`.

### Testing
- No automated tests were run for this content-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a692b24254832089e146e5dbd9ca63)