### PR TITLE
Hide both footer handles by default to prevent simultaneous display

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,6 +101,11 @@
       display: none;
     }
 
+    #footer-hamusata,
+    #footer-hamuzon {
+      display: none;
+    }
+
     @media (max-width:480px) {
       h1 {
         font-size: 1.5rem;

--- a/site.html
+++ b/site.html
@@ -141,6 +141,11 @@
       display: none;
     }
 
+    #footer-hamusata,
+    #footer-hamuzon {
+      display: none;
+    }
+
     @media(max-width:480px) {
       h1 {
         font-size: 1.8rem;


### PR DESCRIPTION
### Motivation
- Prevent both `#footer-hamusata` and `#footer-hamuzon` from being visible at the same time on initial page render before the host-specific JavaScript runs.

### Description
- Add CSS to `index.html` and `site.html` to set `#footer-hamusata` and `#footer-hamuzon` to `display: none` by default while keeping the existing host-based JS that shows the appropriate footer for each domain.

### Testing
- Ran `git diff --check` and `git status --short` and committed the change; the diff check produced no errors and the commit succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c69e419c8320861692b400b21a74)