### PR TITLE
Handle /lit redirect in 404.html to homepage with UTM params

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,9 @@
     const host = window.location.hostname;
     const path = window.location.pathname.toLowerCase();
 
-    if (host === 'hamuzon.github.io' && (path.endsWith('/clock') || path.endsWith('/clock/'))) {
+    if (host === 'hamuzon.github.io' && (path === '/lit' || path === '/lit/')) {
+      window.location.replace('/?utm_source=litlink&utm_medium=social');
+    } else if (host === 'hamuzon.github.io' && (path.endsWith('/clock') || path.endsWith('/clock/'))) {
       window.location.replace('/clock-app/');
     } else if (path.includes('readme') || path.includes('license')) {
       window.location.replace('/');


### PR DESCRIPTION
### Motivation
- Add specific redirect behavior so requests to `https://hamuzon.github.io/lit` and `https://hamuzon.github.io/lit/` navigate to the homepage with UTM parameters for lit links.

### Description
- Modified `404.html` JavaScript to detect `host === 'hamuzon.github.io'` and `path === '/lit'` or `'/lit/'` and call `window.location.replace('/?utm_source=litlink&utm_medium=social')`, while preserving the existing `/clock` and readme/license redirect branches.

### Testing
- No automated tests were run for this static redirect change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c857038c83208dbb0e4d9416292c)