### PR TITLE
Add host-specific sitemap redirect for home.hamusata.f5.si

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -10,3 +10,4 @@
 /bky  /?utm_source=bluesky&utm_medium=social   302
 /tx   /?utm_source=twitter&utm_medium=social   302
 /lit  /?utm_source=litlink&utm_medium=social   302
+https://home.hamusata.f5.si/sitemap.xml   https://home.hamusata.f5.si/public/hamusata.f5.si-sitemap.xml   301


### PR DESCRIPTION
### Motivation
- Add a host-scoped redirect so requests to `https://home.hamusata.f5.si/sitemap.xml` resolve to the canonical `https://home.hamusata.f5.si/public/hamusata.f5.si-sitemap.xml` only for that host.

### Description
- Inserted a 301 redirect rule into `_redirects`: `https://home.hamusata.f5.si/sitemap.xml   https://home.hamusata.f5.si/public/hamusata.f5.si-sitemap.xml   301`.

### Testing
- Verified the new redirect line with `nl -ba _redirects`, confirmed the change via `git status --short`, and committed the change with `git commit`, all of which succeeded.

------
Codex