### PR TITLE
Add Discord redirect to /discord-tools/ in 404 handler

### DIFF
--- a/404.html
+++ b/404.html
@@ -15,6 +15,8 @@
       window.location.replace('/?utm_source=linktree&utm_medium=social');
     } else if (host === 'hamuzon.github.io' && (path.endsWith('/clock') || path.endsWith('/clock/'))) {
       window.location.replace('/clock-app/');
+    } else if (host === 'hamuzon.github.io' && path.includes('discord')) {
+      window.location.replace('/discord-tools/');
     } else if (path.includes('readme') || path.includes('license')) {
       window.location.replace('/');
     }


### PR DESCRIPTION
### Motivation
- Route requests on `hamuzon.github.io` whose path contains `discord` to the new `/discord-tools/` location so users hitting legacy or shorthand Discord URLs are forwarded correctly.

### Description
- Added a new conditional in the `404.html` client-side redirect script that checks `window.location.pathname.toLowerCase()` for `discord` and calls `window.location.replace('/discord-tools/');`.

### Testing
- Committed the change and verified with `git show --stat --oneline -1` and `git status --short`, both commands succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e0597d48832083c235a9e6f63b61)